### PR TITLE
disconnect() and context manager. resolves #2

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,3 +162,28 @@ docs.query(
 ```
 
 For a complete reference, see the [metadata guide](concepts_metadata.md).
+
+
+### Disconnect
+
+When you're done with a collection, be sure to disconnect the client from the database.
+
+```python
+vx.disconnect()
+```
+
+alternatively, use the client as a context manager and it will automatically close the connection on exit.
+
+
+```python
+import vecs
+
+DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
+
+# create vector store client
+with vecs.create_client(DB_CONNECTION) as vx:
+    # do some work here
+    pass
+
+# connections are now closed
+```

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -38,3 +38,16 @@ def test_delete_collection(client: vecs.Client) -> None:
 
     with pytest.raises(vecs.exc.CollectionNotFound):
         client.delete_collection("books")
+
+
+def test_dispose(client: vecs.Client) -> None:
+
+    # Connect and disconnect in context manager
+    with client as connected_client:
+        client.create_collection(name="books", dimension=1)
+        collections = client.list_collections()
+        assert len(collections) == 1
+
+    # engine.dispose re-creates the connection pool so
+    # confirm that the client can still re-connect transparently
+    assert len(client.list_collections()) == 1

--- a/src/vecs/__init__.py
+++ b/src/vecs/__init__.py
@@ -3,7 +3,7 @@ from vecs.client import Client
 from vecs.collection import Collection, IndexMeasure, IndexMethod
 
 __project__ = "vecs"
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 
 __all__ = ["IndexMethod", "IndexMeasure", "Collection", "Client", "exc"]

--- a/src/vecs/client.py
+++ b/src/vecs/client.py
@@ -50,3 +50,14 @@ class Client:
 
         Collection(name, -1, self)._drop()
         return
+
+    def disconnect(self) -> None:
+        self.engine.dispose()
+        return
+
+    def __enter__(self) -> "Client":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+        return


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds options to disconnect the client from postgres manually, automatically via a context manager

---
Example usage:

```python
vx.disconnect()
```

alternatively, use the client as a context manager and it will automatically close the connection on exit.

```python
import vecs
DB_CONNECTION = "postgresql://<user>:<password>@<host>:<port>/<db_name>"
# create vector store client
with vecs.create_client(DB_CONNECTION) as vx:
    # do some work here
    pass
# connections are now closed
```

resolves #2 