### PR TITLE
Metadata `$eq` optimization

### DIFF
--- a/docs/concepts_metadata.md
+++ b/docs/concepts_metadata.md
@@ -46,7 +46,9 @@ Logical operators compose other operators, and can be nested.
 
 ### Performance
 
-For best performance, prefer `$eq`, `$and` and `$or` filters where possible. Those variants are most consistently able to make use of indexes.
+For best performance, use scalar key-value pairs for metadata and prefer `$eq`, `$and` and `$or` filters where possible.
+Those variants are most consistently able to make use of indexes.
+
 
 
 ### Examples

--- a/docs/concepts_metadata.md
+++ b/docs/concepts_metadata.md
@@ -44,6 +44,11 @@ Logical operators compose other operators, and can be nested.
 | $or       |  Joins query clauses with a logical OR returns all documents that match the conditions of either clause. |
 
 
+### Performance
+
+For best performance, prefer `$eq`, `$and` and `$or` filters where possible. Those variants are most consistently able to make use of indexes.
+
+
 ### Examples
 
 ---

--- a/docs/support_changelog.md
+++ b/docs/support_changelog.md
@@ -10,4 +10,4 @@ Initial release
 - Added `vecs.Collection.disconnect()` to drop database connection
 - `vecs.Client` can be used as a context maanger to auto-close connections
 - Added docstrings to all methods, functions and modules
-- Uses (indexed) containment operator `@>` for metadata equality filters
+- Uses (indexed) containment operator `@>` for metadata equality filters where possible

--- a/docs/support_changelog.md
+++ b/docs/support_changelog.md
@@ -10,3 +10,4 @@ Initial release
 - Added `vecs.Collection.disconnect()` to drop database connection
 - `vecs.Client` can be used as a context maanger to auto-close connections
 - Added docstrings to all methods, functions and modules
+- Uses (indexed) containment operator `@>` for metadata equality filters

--- a/src/vecs/__init__.py
+++ b/src/vecs/__init__.py
@@ -3,7 +3,7 @@ from vecs.client import Client
 from vecs.collection import Collection, IndexMeasure, IndexMethod
 
 __project__ = "vecs"
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 
 __all__ = ["IndexMethod", "IndexMeasure", "Collection", "Client", "exc"]


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates metadata filtering to use containment operator `@>` for `$eq` filtering rather than `-> 'key' = 'value'` as it is able to take advantage of the
```
gin ( metadata jsonb_path_ops )
```
index

resolves #11 