### PR TITLE
Allow user definable ivfflat.probes

### DIFF
--- a/src/tests/test_collection.py
+++ b/src/tests/test_collection.py
@@ -173,6 +173,18 @@ def test_query(client: vecs.Client) -> None:
         )
 
     with pytest.raises(vecs.exc.ArgError):
+        res = bar.query(
+            query_vector=query_vec,
+            probes=0,
+        )
+
+    with pytest.raises(vecs.exc.ArgError):
+        res = bar.query(
+            query_vector=query_vec,
+            probes=-1,
+        )
+
+    with pytest.raises(vecs.exc.ArgError):
         res = bar.query(query_vector=query_vec, limit=top_k, measure="invalid")
 
     # include_value
@@ -198,6 +210,15 @@ def test_query(client: vecs.Client) -> None:
     assert len(res[0]) == 2
     assert res[0][0] == "vec5"
     assert res[0][1] == query_meta
+
+    # test for different numbers of probes
+    assert len(bar.query(query_vector=query_vec, limit=top_k, probes=10)) == top_k
+
+    assert len(bar.query(query_vector=query_vec, limit=top_k, probes=5)) == top_k
+
+    assert len(bar.query(query_vector=query_vec, limit=top_k, probes=1)) == top_k
+
+    assert len(bar.query(query_vector=query_vec, limit=top_k, probes=999)) == top_k
 
 
 @pytest.mark.filterwarnings("ignore:Query does")

--- a/src/tests/test_collection.py
+++ b/src/tests/test_collection.py
@@ -185,6 +185,12 @@ def test_query(client: vecs.Client) -> None:
         )
 
     with pytest.raises(vecs.exc.ArgError):
+        res = bar.query(
+            query_vector=query_vec,
+            probes="a",
+        )
+
+    with pytest.raises(vecs.exc.ArgError):
         res = bar.query(query_vector=query_vec, limit=top_k, measure="invalid")
 
     # include_value

--- a/src/vecs/client.py
+++ b/src/vecs/client.py
@@ -96,8 +96,9 @@ class Client:
             CollectionNotFound: If no collection with the given name exists.
         """
         from vecs.collection import Collection
+
         query = text(
-        f"""
+            f"""
         select
             relname as table_name,
             atttypmod as embedding_dim
@@ -114,11 +115,11 @@ class Client:
         """
         ).bindparams(name=name)
         with self.Session() as sess:
-            query_result: Row[Tuple[str, int]] | None = sess.execute(query).fetchone()
+            query_result = sess.execute(query).fetchone()
 
             if query_result is None:
                 raise CollectionNotFound("No collection found with requested name")
-            
+
             name, dimension = query_result
             return Collection(name, dimension, self)
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -162,8 +162,10 @@ class Collection:
             Collection: The newly created collection.
         """
 
-        collection_exists = self.__class__._does_collection_exist(self.client, self.name)
-        if (collection_exists):
+        collection_exists = self.__class__._does_collection_exist(
+            self.client, self.name
+        )
+        if collection_exists:
             raise CollectionAlreadyExists(
                 "Collection with requested name already exists"
             )
@@ -181,8 +183,10 @@ class Collection:
             Collection: The deleted collection.
         """
 
-        collection_exists = self.__class__._does_collection_exist(self.client, self.name)
-        if (not collection_exists):
+        collection_exists = self.__class__._does_collection_exist(
+            self.client, self.name
+        )
+        if not collection_exists:
             raise CollectionNotFound("Collection with requested name not found")
         self.table.drop(self.client.engine)
         return self
@@ -411,7 +415,6 @@ class Collection:
             return True
         except CollectionNotFound:
             return False
-
 
     @property
     def index(self) -> Optional[str]:

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -315,6 +315,9 @@ class Collection:
             Union[List[Record], List[str]]: The result of the similarity search.
         """
 
+        if probes < 1:
+            raise ArgError("probes must be > 10")
+
         if limit > 1000:
             raise ArgError("limit must be <= 1000")
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -296,7 +296,7 @@ class Collection:
         measure: Union[IndexMeasure, str] = IndexMeasure.cosine_distance,
         include_value: bool = False,
         include_metadata: bool = False,
-        probes: int = 10,
+        probes: Optional[int] = None,
     ) -> Union[List[Record], List[str]]:
         """
         Executes a similarity search in the collection.
@@ -310,16 +310,20 @@ class Collection:
             measure (Union[IndexMeasure, str], optional): The distance measure to use for the search. Defaults to 'cosine_distance'.
             include_value (bool, optional): Whether to include the distance value in the results. Defaults to False.
             include_metadata (bool, optional): Whether to include the metadata in the results. Defaults to False.
+            probes (int, optional): Number of ivfflat index lists to query. Higher increases accuracy but decreases speed
 
         Returns:
             Union[List[Record], List[str]]: The result of the similarity search.
         """
 
+        if probes is None:
+            probes = 10
+
         if not isinstance(probes, int):
             raise ArgError("probes must be an integer")
 
         if probes < 1:
-            raise ArgError("probes must be > 10")
+            raise ArgError("probes must be >= 1")
 
         if limit > 1000:
             raise ArgError("limit must be <= 1000")

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -406,31 +406,11 @@ class Collection:
             Exists: Whether the collection exists or not
         """
 
-        query = text(
-        f"""
-        select
-            relname as table_name,
-            atttypmod as embedding_dim
-        from
-            pg_class pc
-            join pg_attribute pa
-                on pc.oid = pa.attrelid
-        where
-            pc.relnamespace = 'vecs'::regnamespace
-            and pc.relkind = 'r'
-            and pa.attname = 'vec'
-            and not pc.relname ^@ '_'
-            and pc.relname = '{name}'
-        """
-        )
-
-        xc = []
-        with client.Session() as sess:
-            for name, dimension in sess.execute(query):
-                existing_collection = cls(name, dimension, client)
-                xc.append(existing_collection)
-        return len(xc) != 0
-
+        try:
+            client.get_collection(name)
+            return True
+        except CollectionNotFound:
+            return False
 
 
     @property

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -310,7 +310,7 @@ class Collection:
             measure (Union[IndexMeasure, str], optional): The distance measure to use for the search. Defaults to 'cosine_distance'.
             include_value (bool, optional): Whether to include the distance value in the results. Defaults to False.
             include_metadata (bool, optional): Whether to include the metadata in the results. Defaults to False.
-            probes (int, optional): Number of ivfflat index lists to query. Higher increases accuracy but decreases speed
+            probes (Optional[Int], optional): Number of ivfflat index lists to query. Higher increases accuracy but decreases speed
 
         Returns:
             Union[List[Record], List[str]]: The result of the similarity search.

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -296,6 +296,7 @@ class Collection:
         measure: Union[IndexMeasure, str] = IndexMeasure.cosine_distance,
         include_value: bool = False,
         include_metadata: bool = False,
+        *,
         probes: Optional[int] = None,
     ) -> Union[List[Record], List[str]]:
         """

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -315,6 +315,9 @@ class Collection:
             Union[List[Record], List[str]]: The result of the similarity search.
         """
 
+        if not isinstance(probes, int):
+            raise ArgError("probes must be an integer")
+
         if probes < 1:
             raise ArgError("probes must be > 10")
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -296,6 +296,7 @@ class Collection:
         measure: Union[IndexMeasure, str] = IndexMeasure.cosine_distance,
         include_value: bool = False,
         include_metadata: bool = False,
+        probes: int = 10,
     ) -> Union[List[Record], List[str]]:
         """
         Executes a similarity search in the collection.
@@ -353,7 +354,9 @@ class Collection:
         with self.client.Session() as sess:
             with sess.begin():
                 # index ignored if greater than n_lists
-                sess.execute(text("set local ivfflat.probes = 10"))
+                sess.execute(
+                    text("set local ivfflat.probes = :probes").bindparams(probes=probes)
+                )
                 if len(cols) == 1:
                     return [str(x) for x in sess.scalars(stmt).fetchall()]
                 return sess.execute(stmt).fetchall() or []


### PR DESCRIPTION
## What kind of change does this PR introduce?

This allows the user to pass in a `probes` parameter to the `Collection.query()` function. This sets the number of `ivfflat.probes` for a query.

## What is the current behavior?

Currently, the number of probes is always set to 10

## What is the new behavior?

If the parameter is not set, it remains as 10 to prevent breaking changes. If the user passes in an integer that is => 1, then the number of probes is forwarded to the session query. A number of probes that is < 1 or not an integer will raise an `ArgError`

## Additional context

Resolves #19
