### PR TITLE
Doc versioning

### DIFF
--- a/docs/concepts_collections.md
+++ b/docs/concepts_collections.md
@@ -1,8 +1,8 @@
 # Collections
 
 A collection is an group of vector records.
-Records can be [added to or updated in](/vecs/api/#upserting-vectors) a collection.
-Collections can be [queried](/vecs/api/#query) at any time, but should be [indexed](/vecs/api/#create-an-index) for scalable query performance.
+Records can be [added to or updated in](api.md/#upserting-vectors) a collection.
+Collections can be [queried](api.md/#query) at any time, but should be [indexed](api.md/#create-an-index) for scalable query performance.
 
 Each vector record has the form:
 

--- a/docs/concepts_indexes.md
+++ b/docs/concepts_indexes.md
@@ -1,8 +1,8 @@
 # Indexes
 
-Indexes are tools for optimizing query performance of a [collection](/vecs/concepts_collections).
+Indexes are tools for optimizing query performance of a [collection](concepts_collections.md).
 
-Collections can be [queried](/vecs/api/#query) without an index, but that will emit a python warning and should never be done in produciton.
+Collections can be [queried](api.md/#query) without an index, but that will emit a python warning and should never be done in produciton.
 
 ```text
 query does not have a covering index for cosine_similarity. See Collection.create_index

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ repo_name: supabase/vecs
 repo_url: https://github.com/supabase/vecs
 
 theme:
-    name: 'material'
+    name: 'readthedocs'
     features:
       - navigation.expand
     palette:

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,13 @@ setuptools.setup(
     install_requires=REQUIRES,
     extras_require={
         "dev": ["pytest", "parse", "numpy", "pytest-cov"],
-        "docs": ["mkdocs", "pygments", "pymdown-extensions", "pymarkdown"],
+        "docs": [
+            "mkdocs",
+            "pygments",
+            "pymdown-extensions",
+            "pymarkdown",
+            "mike",
+        ],
         "text_embedding": ["sentence-transformers==2.*"],
     },
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Add versioning and a version selector to docs via [mike](https://github.com/jimporter/mike#setting-the-default-version)

This change allows 

## Deployment

### Initial Setup

On initial setup, delete existing docs
```
mike delete --all
```

### Build docs locally under a version name and an alias
```
mike deploy --update-aliases 0.3 latest
```

add `--push` to deploy to GitHub Pages

### Build docs locally without an alias
```
mike deploy 0.3
```

### Serve docs locally
```
mike serve
```

### Set default version
```
mike set-default 0.3
```


See preview