### PR TITLE
Correct Broken Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ---
 
-**Documentation**: <a href="https://supabase.github.io/vecs/api/" target="_blank">https://supabase.github.io/vecs/api/</a>
+**Documentation**: <a href="https://supabase.github.io/vecs/" target="_blank">https://supabase.github.io/vecs/</a>
 
 **Source Code**: <a href="https://github.com/supabase/vecs" target="_blank">https://github.com/supabase/vecs</a>
 


### PR DESCRIPTION
Updates the link in the README to point to the same doc location as the about section.

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

It's pointing to /api which doesn't exist.
