### PR TITLE
Fix: GitHub pages redirects

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/api'" />
+</head>
+
+<body></body>
+
+</html>

--- a/concepts_adapters/index.html
+++ b/concepts_adapters/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/concepts_adapters'" />
+</head>
+
+<body></body>
+
+</html>

--- a/concepts_collections/index.html
+++ b/concepts_collections/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/concepts_collections'" />
+</head>
+
+<body></body>
+
+</html>

--- a/concepts_indexes/index.html
+++ b/concepts_indexes/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/concepts_indexes'" />
+</head>
+
+<body></body>
+
+</html>

--- a/concepts_metadata/index.html
+++ b/concepts_metadata/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/concepts_metadata'" />
+</head>
+
+<body></body>
+
+</html>

--- a/hosting/index.html
+++ b/hosting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/hosting'" />
+</head>
+
+<body></body>
+
+</html>

--- a/integrations_huggingface_inference_endpoints/index.html
+++ b/integrations_huggingface_inference_endpoints/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/integrations_huggingface_inference_endpoints'" />
+</head>
+
+<body></body>
+
+</html>

--- a/integrations_openai/index.html
+++ b/integrations_openai/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/integrations_openai'" />
+</head>
+
+<body></body>
+
+</html>

--- a/support_changelog/index.html
+++ b/support_changelog/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta http-equiv="refresh" content="0; URL='../latest/support_changelog'" />
+</head>
+
+<body></body>
+
+</html>


### PR DESCRIPTION
After switching to [`mike`](https://github.com/jimporter/mike) for doc versioning and [removing the old pages](https://github.com/supabase/vecs/commit/8add2b9f128aaf2f3bb81550dec21470e377c742), external links to the old pages result in a 404.

This adds back those pages with HTML to redirect the page appropriately:
```html
<meta http-equiv="refresh" content="0; URL='../latest/api'" />
```