### PR TITLE
Docs reference 0.4. mike not redirecting on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ---
 
-**Documentation**: <a href="https://supabase.github.io/vecs/api/" target="_blank">https://supabase.github.io/vecs/api/</a>
+**Documentation**: <a href="https://supabase.github.io/vecs/0.4/" target="_blank">https://supabase.github.io/vecs/</a>
 
 **Source Code**: <a href="https://github.com/supabase/vecs" target="_blank">https://github.com/supabase/vecs</a>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@
 
 ---
 
-**Documentation**: <a href="https://supabase.github.io/vecs/api/" target="_blank">https://supabase.github.io/vecs/api/</a>
+**Documentation**: <a href="https://supabase.github.io/vecs/0.4/" target="_blank">https://supabase.github.io/vecs/</a>
 
 **Source Code**: <a href="https://github.com/supabase/vecs" target="_blank">https://github.com/supabase/vecs</a>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Explicitly reference version 0.4 for docs landing page on README and index. For some reason mike is redirecting all pages that don't include a version number except from the home page. Updating this value will have to be part of there release process.