### PR TITLE
feat: add ability to delete by filtering metadata only

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,10 +62,12 @@ docs.upsert(
 
 ## Deleting vectors
 
-Deleting records removes them from the collection. To delete records, specify a list of `ids` to the `delete` method. The ids of the sucessfully deleted records are returned from the method. Note that attempting to delete non-existent records does not raise an error.
+Deleting records removes them from the collection. To delete records, specify a list of `ids` or metadata filters to the `delete` method. The ids of the sucessfully deleted records are returned from the method. Note that attempting to delete non-existent records does not raise an error.
 
 ```python
 docs.delete(ids=["vec0", "vec1"])
+# or delete with filters
+docs.delete(filters={"year": {"$eq": 2012}})
 ```
 
 ## Create an index

--- a/docs/api.md
+++ b/docs/api.md
@@ -66,7 +66,7 @@ Deleting records removes them from the collection. To delete records, specify a 
 
 ```python
 docs.delete(ids=["vec0", "vec1"])
-# or delete with filters
+# or delete by a metadata filter
 docs.delete(filters={"year": {"$eq": 2012}})
 ```
 

--- a/src/tests/test_collection.py
+++ b/src/tests/test_collection.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 
 import numpy as np
@@ -91,11 +92,14 @@ def test_delete(client: vecs.Client) -> None:
             f"vec{ix}",
             vec,
             {
-                "genre": random.choice(["action", "rom-com", "drama"]),
+                "genre": genre,
                 "year": int(50 * random.random()) + 1970,
             },
         )
-        for ix, vec in enumerate(np.random.random((n_records, dim)))
+        for (ix, vec), genre in zip(
+            enumerate(np.random.random((n_records, dim))),
+            itertools.cycle(["action", "rom-com", "drama"]),
+        )
     ]
 
     # insert works
@@ -112,7 +116,7 @@ def test_delete(client: vecs.Client) -> None:
     # delete with filters
     genre_to_delete = "action"
     deleted_ids_by_genre = movies.delete(filters={"genre": {"$eq": genre_to_delete}})
-    assert len(deleted_ids_by_genre) > 0
+    assert len(deleted_ids_by_genre) == 34
 
     # bad input
     with pytest.raises(vecs.exc.ArgError):

--- a/src/tests/test_collection.py
+++ b/src/tests/test_collection.py
@@ -111,8 +111,7 @@ def test_delete(client: vecs.Client) -> None:
 
     # delete with filters
     genre_to_delete = "action"
-    deleted_ids_by_genre = movies.delete(
-        filters={"genre": {"$eq": genre_to_delete}})
+    deleted_ids_by_genre = movies.delete(filters={"genre": {"$eq": genre_to_delete}})
     assert len(deleted_ids_by_genre) > 0
 
     # bad input
@@ -125,8 +124,7 @@ def test_delete(client: vecs.Client) -> None:
 
     # bad input: should only provide either ids or filters, not both
     with pytest.raises(vecs.exc.ArgError):
-        movies.delete(ids=["vec0"], filters={
-                      "genre": {"$eq": genre_to_delete}})
+        movies.delete(ids=["vec0"], filters={"genre": {"$eq": genre_to_delete}})
 
 
 def test_repr(client: vecs.Client) -> None:

--- a/src/tests/test_collection.py
+++ b/src/tests/test_collection.py
@@ -101,13 +101,32 @@ def test_delete(client: vecs.Client) -> None:
     # insert works
     movies.upsert(records)
 
+    # delete by IDs.
     delete_ids = ["vec0", "vec15", "vec99"]
     movies.delete(ids=delete_ids)
     assert len(movies) == n_records - len(delete_ids)
 
+    # insert works
+    movies.upsert(records)
+
+    # delete with filters
+    genre_to_delete = "action"
+    deleted_ids_by_genre = movies.delete(
+        filters={"genre": {"$eq": genre_to_delete}})
+    assert len(deleted_ids_by_genre) > 0
+
     # bad input
     with pytest.raises(vecs.exc.ArgError):
         movies.delete(ids="should_be_a_list")
+
+    # bad input: neither ids nor filters provided.
+    with pytest.raises(vecs.exc.ArgError):
+        movies.delete()
+
+    # bad input: should only provide either ids or filters, not both
+    with pytest.raises(vecs.exc.ArgError):
+        movies.delete(ids=["vec0"], filters={
+                      "genre": {"$eq": genre_to_delete}})
 
 
 def test_repr(client: vecs.Client) -> None:

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -395,6 +395,16 @@ class Collection:
         return del_ids
 
     def delete_vectors(self, ids: Optional[Iterable[str]] = None, metadata: Optional[Metadata] = None) -> List[str]:
+        """
+        Deletes vectors from the collection by matching metadata.
+
+        Args:
+            ids (Iterable[str]): An iterable of vector identifiers.
+            metadata (Metadata): A dictionary of metadata key-value pairs to match.
+
+        Returns:
+            List[str]: A list of the identifiers of the deleted vectors.
+        """
         if ids is None and metadata is None:
             raise VectorDeletionError("Either ids or metadata must be provided.")
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -418,7 +418,7 @@ class Collection:
                         delete(self.table).where(meta_filter).returning(self.table.c.id)  # type: ignore
                     )
                     result = sess.execute(stmt).scalars()
-                    del_ids.extend([row for row in result.fetchall()])
+                    del_ids.extend(result.fetchall())
 
         return del_ids
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -381,10 +381,8 @@ class Collection:
         del_ids = []
         with self.client.Session() as sess:
             with sess.begin():
-                # Build the filter for the metadata
                 meta_filter = build_filters(self.table.c.metadata, metadata)
                 
-                # Perform the delete operation
                 stmt = (
                     delete(self.table)
                     .where(meta_filter)
@@ -424,7 +422,6 @@ class Collection:
                         del_ids.extend(sess.execute(stmt).scalars() or [])
                 
                 if metadata is not None:
-                    # Assuming build_filters is a previously defined function
                     meta_filter = build_filters(self.table.c.metadata, metadata)
                     stmt = (
                         delete(self.table)

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -536,8 +536,8 @@ class Collection:
         stmt = select(*cols)
         if filters:
             stmt = stmt.filter(
-                build_filters(self.table.c.metadata, filters)
-            )  # type: ignore
+                build_filters(self.table.c.metadata, filters)  # type: ignore
+            )
 
         stmt = stmt.order_by(distance_clause)
         stmt = stmt.limit(limit)

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -417,8 +417,8 @@ class Collection:
                     stmt = (
                         delete(self.table).where(meta_filter).returning(self.table.c.id)  # type: ignore
                     )
-                    result = sess.execute(stmt)
-                    del_ids.extend([row[0] for row in result.fetchall()])
+                    result = sess.execute(stmt).scalars()
+                    del_ids.extend([row for row in result.fetchall()])
 
         return del_ids
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -382,8 +382,8 @@ class Collection:
         Deletes vectors from the collection by matching filters or ids.
 
         Args:
-            ids (Iterable[str]): An iterable of vector identifiers.
-            filters (Metadata): A dictionary of metadata key-value pairs to match.
+            ids (Iterable[str], optional): An iterable of vector identifiers.
+            filters (Optional[Dict], optional): Filters to apply to the search. Defaults to None.
 
         Returns:
             List[str]: A list of the identifiers of the deleted vectors.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

I need to be able to delete vectors based solely on their metadata but currently the only way to do so is to already have the ids.

## What is the new behavior?

I added 2 methods as suggestions.
Option #1: add a `delete_by_metadata`
Option #2: `delete_vectors` (temporary name) a suggestion for updating the current `delete` function to allow optionally passing the ids or metdata (one or the other).

Please let me know which is an acceptable approach and if there are any objections to having this capability.
