### PR TITLE
Add index build arguments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -101,16 +101,19 @@ Available options for index `method` are:
 
 Where `auto` selects the best available index method, `hnsw` uses the [HNSW](https://github.com/pgvector/pgvector#hnsw) method and `ivfflat` uses [IVFFlat](https://github.com/pgvector/pgvector#ivfflat).
 
+HNSW and IVFFlat indexes both allow for parameterization to control the speed/accuracy tradeoff. vecs provides sane defaults for these parameters. For a greater level of control you can optionally pass an instance of `vecs.IndexArgsIVFFlat` or `vecs.IndexArgsHNSW` to `create_index`'s `index_arguments` argument. Descriptions of the impact for each parameter are available in the [pgvector docs](https://github.com/pgvector/pgvector).
+
 When using IVFFlat indexes, the index must be created __after__ the collection has been populated with records. Building an IVFFlat index on an empty collection will result in significantly reduced recall. You can continue upserting new documents after the index has been created, but should rebuild the index if the size of the collection more than doubles since the last index operation.
 
 HNSW indexes can be created immediately after the collection without populating records.
 
-To manually specify `method` and `measure`, add them as arguments to `create_index` for example:
+To manually specify `method`, `measure`, and `index_arguments` add them as arguments to `create_index` for example:
 
 ```python
 docs.create_index(
     method=IndexMethod.hnsw,
     measure=IndexMeasure.cosine_distance,
+    measure=IndexArgsHNSW(m=8),
 )
 ```
 

--- a/docs/concepts_indexes.md
+++ b/docs/concepts_indexes.md
@@ -40,16 +40,19 @@ Available options for index `method` are:
 
 Where `auto` selects the best available index method, `hnsw` uses the [HNSW](https://github.com/pgvector/pgvector#hnsw) method and `ivfflat` uses [IVFFlat](https://github.com/pgvector/pgvector#ivfflat).
 
+HNSW and IVFFlat indexes both allow for parameterization to control the speed/accuracy tradeoff. vecs provides sane defaults for these parameters. For a greater level of control you can optionally pass an instance of `vecs.IndexArgsIVFFlat` or `vecs.IndexArgsHNSW` to `create_index`'s `index_arguments` argument. Descriptions of the impact for each parameter are available in the [pgvector docs](https://github.com/pgvector/pgvector).
+
 When using IVFFlat indexes, the index must be created __after__ the collection has been populated with records. Building an IVFFlat index on an empty collection will result in significantly reduced recall. You can continue upserting new documents after the index has been created, but should rebuild the index if the size of the collection more than doubles since the last index operation.
 
 HNSW indexes can be created immediately after the collection without populating records.
 
-To manually specify `method` and `measure`, ass them as arguments to `create_index` for example:
+To manually specify `method`, `measure`, and `index_arguments` add them as arguments to `create_index` for example:
 
 ```python
 docs.create_index(
     method=IndexMethod.hnsw,
     measure=IndexMeasure.cosine_distance,
+    measure=IndexArgsHNSW(m=8),
 )
 ```
 

--- a/docs/support_changelog.md
+++ b/docs/support_changelog.md
@@ -32,3 +32,5 @@
 - Bugfix: removed errant print statement
 
 ## master
+
+- Feature: Parameterized IVFFlat and HNSW indexes

--- a/src/vecs/__init__.py
+++ b/src/vecs/__init__.py
@@ -1,12 +1,26 @@
 from vecs import exc
 from vecs.client import Client
-from vecs.collection import Collection, IndexMeasure, IndexMethod
+from vecs.collection import (
+    Collection,
+    IndexArgsHNSW,
+    IndexArgsIVFFlat,
+    IndexMeasure,
+    IndexMethod,
+)
 
 __project__ = "vecs"
 __version__ = "0.4.1"
 
 
-__all__ = ["IndexMethod", "IndexMeasure", "Collection", "Client", "exc"]
+__all__ = [
+    "IndexArgsIVFFlat",
+    "IndexArgsHSNW",
+    "IndexMethod",
+    "IndexMeasure",
+    "Collection",
+    "Client",
+    "exc",
+]
 
 
 def create_client(connection_string: str) -> Client:

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import math
 import uuid
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -80,6 +81,40 @@ class IndexMeasure(str, Enum):
     cosine_distance = "cosine_distance"
     l2_distance = "l2_distance"
     max_inner_product = "max_inner_product"
+
+
+@dataclass
+class IndexArgsIVFFlat:
+    """
+    A class for arguments that can optionally be supplied to the index creation
+    method when building an IVFFlat type index.
+
+    Attributes:
+        nlist (int): The number of IVF centroids that the index should use
+    """
+
+    n_lists: int
+
+
+@dataclass
+class IndexArgsHNSW:
+    """
+    A class for arguments that can optionally be supplied to the index creation
+    method when building an HNSW type index.
+
+    Ref: https://github.com/pgvector/pgvector#index-options
+
+    Both attributes are Optional in case the user only wants to specify one and
+    leave the other as default
+
+    Attributes:
+        m (int): Maximum number of connections per node per layer (default: 16)
+        ef_construction (int): Size of the dynamic candidate list for
+            constructing the graph (default: 64)
+    """
+
+    m: Optional[int] = 16
+    ef_construction: Optional[int] = 64
 
 
 INDEX_MEASURE_TO_OPS = {
@@ -621,6 +656,7 @@ class Collection:
         self,
         measure: IndexMeasure = IndexMeasure.cosine_distance,
         method: IndexMethod = IndexMethod.auto,
+        index_arguments: Optional[Union[IndexArgsIVFFlat, IndexArgsHNSW]] = None,
         replace=True,
     ) -> None:
         """
@@ -653,6 +689,7 @@ class Collection:
         Raises:
             ArgError: If an invalid index method is used, or if *replace* is False and an index already exists.
         """
+
         if not method in (IndexMethod.ivfflat, IndexMethod.hnsw, IndexMethod.auto):
             raise ArgError("invalid index method")
 
@@ -666,6 +703,24 @@ class Collection:
             raise ArgError(
                 "HNSW Unavailable. Upgrade your pgvector installation to > 0.5.0 to enable HNSW support"
             )
+
+        # Catch case where use submits index build args for one index type but
+        # method defines a different index type.
+        if index_arguments and (
+            (isinstance(index_arguments, IndexArgsHNSW) and method != IndexMethod.hnsw)
+            or (
+                isinstance(index_arguments, IndexArgsIVFFlat)
+                and method != IndexMethod.ivfflat
+            )
+        ):
+            warnings.warn(
+                UserWarning(
+                    f"{index_arguments.__class__.__name__} build parameters were supplied but {method} index was specified. Default parameters for {method} index will be used instead."
+                )
+            )
+            # set index_arguments to None in order to instantiate
+            # with the default values later
+            index_arguments = None
 
         ops = INDEX_MEASURE_TO_OPS.get(measure)
         if ops is None:
@@ -683,18 +738,27 @@ class Collection:
                         raise ArgError("replace is set to False but an index exists")
 
                 if method == IndexMethod.ivfflat:
-                    n_records: int = sess.execute(func.count(self.table.c.id)).scalar()  # type: ignore
+                    if not index_arguments:
+                        n_records: int = sess.execute(func.count(self.table.c.id)).scalar()  # type: ignore
 
-                    n_lists = (
-                        int(max(n_records / 1000, 30))
-                        if n_records < 1_000_000
-                        else int(math.sqrt(n_records))
-                    )
+                        n_lists = (
+                            int(max(n_records / 1000, 30))
+                            if n_records < 1_000_000
+                            else int(math.sqrt(n_records))
+                        )
+                    else:
+                        # The following mypy error is ignored because mypy
+                        # complains that `index_arguments` is typed as a union
+                        # of IndexArgsIVFFlat and IndexArgsHNSW types,
+                        # which both don't necessarily contain the `n_lists`
+                        # parameter, however we have validated that the
+                        # correct type is being used above.
+                        n_lists = index_arguments.n_lists  # type: ignore
 
                     sess.execute(
                         text(
                             f"""
-                            create index ix_{ops}_ivfflat_{n_lists}_{unique_string}
+                            create index ix_{ops}_ivfflat_nl{n_lists}_{unique_string}
                               on vecs."{self.table.name}"
                               using ivfflat (vec {ops}) with (lists={n_lists})
                             """
@@ -702,12 +766,20 @@ class Collection:
                     )
 
                 if method == IndexMethod.hnsw:
+                    if not index_arguments:
+                        index_arguments = IndexArgsHNSW()
+
+                    # See above for explanation of why the following lines
+                    # are ignored
+                    m = index_arguments.m  # type: ignore
+                    ef_construction = index_arguments.ef_construction  # type: ignore
+
                     sess.execute(
                         text(
                             f"""
-                            create index ix_{ops}_hnsw_{unique_string}
+                            create index ix_{ops}_hnsw_m{m}_efc{ef_construction}_{unique_string}
                               on vecs."{self.table.name}"
-                              using hnsw (vec {ops});
+                              using hnsw (vec {ops}) WITH (m={m}, ef_construction={ef_construction});
                             """
                         )
                     )

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -684,6 +684,7 @@ class Collection:
         Args:
             measure (IndexMeasure, optional): The measure to index for. Defaults to 'cosine_distance'.
             method (IndexMethod, optional): The indexing method to use. Defaults to 'auto'.
+            index_arguments: (IndexArgsIVFFlat | IndexArgsHNSW, optional): Index type specific arguments
             replace (bool, optional): Whether to replace the existing index. Defaults to True.
 
         Raises:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

See [supabase/vecs/issues/56](https://github.com/supabase/vecs/issues/56)

## What is the new behavior?

Indexes can now be built with specific parameters (`n_lists` for IndexIVFFlat and `m`,`ef_construction` for IndexHSNW). PGvector default values are used in absence of user-supplied parameters and a warning will be raised if the user requests an index of one type but supplies arguments corresponding to a different type (eg: create index with type `vecs.IndexMethod.hsnw` and supply `index_arguments=vecs.IndexArgsIVFFlat(n_lists=123)`).

*Note*: this PR also changes the naming scheme for indexes slightly. Currently the indexes are named: 
`index ix_{ops}_ivfflat_{n_lists}_{unique_string}` and `ix_{ops}_hnsw_{unique_string}` for `IndexIVFFlat` and `IndexHNSW` , respectively. Since the values of `m` and `ef_construction` are customizable and not easily accessible from the vecs client, it makes sense to encode these in the index name, similarly to the value of `n_lists` in the `IndexIVFFlat` index.

In order to avoid confusion between the two `IndexHNSW` build values in the index name, the values have been prepended with `m` and `efc` respectively. To maintain consistency, the `n_lists` value in the `IndexIVFFLat` is prepended with `nl`. So index names now looks like: `ix_{ops}_ivfflat_nl{n_lists}_{unique_string}` for `IndexIVFFlat` and `ix_{ops}_hnsw_m{m}_efc{ef_construction}_{unique_string}` for `IndexHSNW`.

Examples: 
```python 
# c = client.get_or_create_collection(...)
# c.upsert(...)

# IVFFlat: no index build args, use default 
c.create_index(method=vecs.IndexMethod.ivfflat)
c.index
>>> 'ix_vector_cosine_ops_ivfflat_nl30_4ae41f2'

# IVFFlat: custom build args  
c.create_index(method=vecs.IndexMethod.ivfflat, index_arguments=vecs.IndexArgsIVFFlat(n_lists=123))
c.index
>>> 'ix_vector_cosine_ops_ivfflat_nl123_771ceda'

# HNSW: no index build args, use default 
c.create_index(method=vecs.IndexMethod.hnsw)
c.index
>>> 'ix_vector_cosine_ops_hnsw_m16_efc64_0ad32a1'

# HNSW: custom build args: 
c.create_index(method=vecs.IndexMethod.hnsw, index_arguments=vecs.IndexArgsHNSW(m=12, ef_construction=123))
c.index
>>> 'ix_vector_cosine_ops_hnsw_m12_efc123_bdcd632'

# Warning when index of one type is request but the index build arguments are supplied, use default values
c.create_index(method=vecs.IndexMethod.ivfflat, index_arguments=vecs.IndexArgsHNSW(m=12, ef_construction=123))
>>> /supabase/vecs/src/vecs/collection.py:726: UserWarning: IndexArgsHNSW build parameters were supplied but IndexMethod.ivfflat index was specified. Default parameters for IndexMethod.ivfflat index will be used instead.
c.index
>>> 'ix_vector_cosine_ops_ivfflat_nl30_32337d4'

c.create_index(method=vecs.IndexMethod.hnsw, index_arguments=vecs.IndexArgsIVFFlat(n_lists=123))
>>> /supabase/vecs/src/vecs/collection.py:726: UserWarning: IndexArgsIVFFlat build parameters were supplied but IndexMethod.hnsw index was specified. Default parameters for IndexMethod.hnsw index will be used instead.
c.index
>>> 'ix_vector_cosine_ops_hnsw_m16_efc64_be3f38f'
```
