### PR TITLE
smol fix

### DIFF
--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -321,9 +321,12 @@ class Collection:
         Inserts or updates *vectors* records in the collection.
 
         Args:
-            records (Iterable[Tuple[str, Any, Metadata]]): An iterable of vectors to upsert.
-                Each vector is represented as a tuple where the first element is a unique string identifier,
-                the second element is an iterable of numeric values, and the third element is metadata associated with the vector.
+            records (Iterable[Tuple[str, Any, Metadata]]): An iterable of content to upsert.
+                Each record is a tuple where:
+                  - the first element is a unique string identifier
+                  - the second element is an iterable of numeric values or relevant input type for the
+                    adapter assigned to the collection
+                  - the third element is metadata associated with the vector
 
             skip_adapter (bool): Should the adapter be skipped while upserting. i.e. if vectors are being
                 provided, rather than a media type that needs to be transformed

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -321,7 +321,7 @@ class Collection:
         Inserts or updates *vectors* records in the collection.
 
         Args:
-            vectors (Iterable[Tuple[str, Any, Metadata]]): An iterable of vectors to upsert.
+            records (Iterable[Tuple[str, Any, Metadata]]): An iterable of vectors to upsert.
                 Each vector is represented as a tuple where the first element is a unique string identifier,
                 the second element is an iterable of numeric values, and the third element is metadata associated with the vector.
 

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -460,7 +460,7 @@ class Collection:
         The return type is dependent on arguments *include_value* and *include_metadata*
 
         Args:
-            query_vector (Any): The vector to use as the query.
+            data (Any): The vector to use as the query.
             limit (int, optional): The maximum number of results to return. Defaults to 10.
             filters (Optional[Dict], optional): Filters to apply to the search. Defaults to None.
             measure (Union[IndexMeasure, str], optional): The distance measure to use for the search. Defaults to 'cosine_distance'.


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix, you should also probably update your doc to use "records" but also, you can just change to use "vectors"

https://supabase.com/docs/guides/ai/vecs-python-client

## What is the current behavior?

ERROR
<img width="1024" alt="Screenshot 2023-11-15 at 7 17 10 PM" src="https://github.com/supabase/vecs/assets/1545487/14813f53-3b27-4fa9-b4e2-4474553da3be">


## What is the new behavior?

NO ERROR

## Additional context

Add any other context or screenshots.
