### PR TITLE
Small docs typo fix

### DIFF
--- a/docs/concepts_collections.md
+++ b/docs/concepts_collections.md
@@ -15,11 +15,12 @@ Record (
 ```
 
 For example:
+
 ```python
 ("vec1", [0.1, 0.2, 0.3], {"year": 1990})
 ```
 
-Underneath every `vecs` a collection is Postgres table
+Underneath every `vecs` collection is a Postgres table
 
 ```sql
 create table <collection_name> (
@@ -28,6 +29,7 @@ create table <collection_name> (
     metadata jsonb
 )
 ```
+
 where rows in the table map 1:1 with vecs vector records.
 
 It is safe to select collection tables from outside the vecs client but issuing DDL is not recommended.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

<img width="449" alt="Screenshot 2023-11-18 at 10 34 51 PM" src="https://github.com/supabase/vecs/assets/16231195/03188a8b-e5b6-4672-94a1-4ba5ca518675">

## What is the new behavior?
<img width="527" alt="Screenshot 2023-11-18 at 10 35 17 PM" src="https://github.com/supabase/vecs/assets/16231195/2c27d684-be02-4a2f-b8a5-af08cc91ade7">

## Additional context

Feel free to let me know if I need to run some sort of build commands or make the change elsewhere in the codebase.

Add any other context or screenshots.
