### PR TITLE
Correct index_arguments arg in `create_index` method in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,7 +115,7 @@ To manually specify `method`, `measure`, and `index_arguments` add them as argum
 docs.create_index(
     method=IndexMethod.hnsw,
     measure=IndexMeasure.cosine_distance,
-    measure=IndexArgsHNSW(m=8),
+    index_arguments=IndexArgsHNSW(m=8),
 )
 ```
 

--- a/docs/concepts_indexes.md
+++ b/docs/concepts_indexes.md
@@ -52,7 +52,7 @@ To manually specify `method`, `measure`, and `index_arguments` add them as argum
 docs.create_index(
     method=IndexMethod.hnsw,
     measure=IndexMeasure.cosine_distance,
-    measure=IndexArgsHNSW(m=8),
+    index_arguments=IndexArgsHNSW(m=8),
 )
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
corrects an argument name in documentation

the fix has already been deployed


ref #75 