### PR TITLE
Feat: add new filter operator "$contains"

### DIFF
--- a/docs/concepts_metadata.md
+++ b/docs/concepts_metadata.md
@@ -33,7 +33,7 @@ Comparison operators compare a provided value with a value stored in metadata fi
 | $lt       | Matches values that are less than a specified value |
 | $lte      | Matches values that are less than or equal to a specified value |
 | $in       | Matches values that are contained by scalar list of specified values |
-| $contains | Matches values where a specified value is contained within the metadata field value |
+| $contains | Matches values where a scalar is contained within an array metadata field |
 
 
 ### Logical Operators
@@ -99,7 +99,7 @@ Those variants are most consistently able to make use of indexes.
 }
 ```
 
-`tags` contain "important"
+`tags`, an array, contains the string "important"
 
 ```json
 {

--- a/docs/concepts_metadata.md
+++ b/docs/concepts_metadata.md
@@ -33,6 +33,7 @@ Comparison operators compare a provided value with a value stored in metadata fi
 | $lt       | Matches values that are less than a specified value |
 | $lte      | Matches values that are less than or equal to a specified value |
 | $in       | Matches values that are contained by scalar list of specified values |
+| $contains | Matches values where a specified value is contained within the metadata field value |
 
 
 ### Logical Operators
@@ -95,5 +96,13 @@ Those variants are most consistently able to make use of indexes.
 ```json
 {
     "priority": {"$in": ["enterprise", "pro"]}
+}
+```
+
+`tags` contain "important"
+
+```json
+{
+    "tags": {"$contains": "important"}
 }
 ```

--- a/src/vecs/collection.py
+++ b/src/vecs/collection.py
@@ -860,7 +860,7 @@ def build_filters(json_col: Column, filters: Dict):
             if len(value) > 1:
                 raise FilterError("only one operator permitted")
             for operator, clause in value.items():
-                if operator not in ("$eq", "$ne", "$lt", "$lte", "$gt", "$gte", "$in"):
+                if operator not in ("$eq", "$ne", "$lt", "$lte", "$gt", "$gte", "$in", '$contains'):
                     raise FilterError("unknown operator")
 
                 # equality of singular values can take advantage of the metadata index
@@ -884,6 +884,10 @@ def build_filters(json_col: Column, filters: Dict):
                     # directly compare json types in the query
                     contains_value = [cast(elem, postgresql.JSONB) for elem in clause]
                     return json_col.op("->")(key).in_(contains_value)
+
+                if operator == "$contains":
+                    contains_value = cast(clause, postgresql.JSONB)
+                    return json_col.op("->")(key).contains(contains_value)
 
                 matches_value = cast(clause, postgresql.JSONB)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

I need to be able to filter vectors by tag but I can't because there is no way to filter array metadata

## What is the new behavior?

I added the new operator "$contains"
now we can have an array in metadata like ['sales', "marketing", "development"]

```
collection.query(
            data=[...],
            include_metadata=True,
            include_value=True,
            filters={"tags": {"$contains": "development"}})
```