### PR TITLE
Fixes concepts_indexes typo

### DIFF
--- a/docs/concepts_indexes.md
+++ b/docs/concepts_indexes.md
@@ -10,7 +10,7 @@ query does not have a covering index for cosine_similarity. See Collection.creat
 
 As each query vector must be checked against every record in the collection. When the number of dimensions and/or number of records becomes large, that becomes extremely slow and computationally expensive.
 
-An index is a heuristic datastructure that pre-computes distances among key points in the vector space. It is smaller and can be traversed more quickly than the whole collection enabling __much__ more performant seraching.
+An index is a heuristic datastructure that pre-computes distances among key points in the vector space. It is smaller and can be traversed more quickly than the whole collection enabling __much__ more performant searching.
 
 Only one index may exist per-collection. An index optimizes a collection for searching according to a selected distance measure.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates the docs.

Bug fix, feature, docs update, ...

## What is the current behavior?

Before: ![image](https://github.com/supabase/vecs/assets/90329779/57691b5e-a629-4e4d-b693-a21417a3b788)

See this issue on supabase: [Supabase issue](https://github.com/supabase/supabase/issues/27791)

Please link any relevant issues here.

## What is the new behavior?

After: 
![image](https://github.com/supabase/vecs/assets/90329779/b69b58f8-2493-45ba-93cd-080fe62d5446)


Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
