### PR TITLE
Fixes Indexes Typo mistakes ( Resolve Issue #27791 )

### DIFF
--- a/docs/concepts_indexes.md
+++ b/docs/concepts_indexes.md
@@ -10,7 +10,7 @@ query does not have a covering index for cosine_similarity. See Collection.creat
 
 As each query vector must be checked against every record in the collection. When the number of dimensions and/or number of records becomes large, that becomes extremely slow and computationally expensive.
 
-An index is a heuristic datastructure that pre-computes distances among key points in the vector space. It is smaller and can be traversed more quickly than the whole collection enabling __much__ more performant seraching.
+An index is a heuristic data structure that pre-computes distances between key points in the vector space. It is smaller and can be traversed more quickly than the whole collection enabling much more performant searching.
 
 Only one index may exist per-collection. An index optimizes a collection for searching according to a selected distance measure.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #86
Indexes page have typing mistake that makes new developer to understanding, Docs Update and Resolve Typo mistakes at https://supabase.com/docs/guides/ai/python/indexes

## What is the current behavior?
**Before**:
![Before the changes](https://github.com/supabase/vecs/assets/108121667/fab6098b-6bcc-454a-9e74-8cf973e458ee)

Please link any relevant issues here.
[Spelling Mistake #27791](1https://github.com/supabase/supabase/issues/27791)

## What is the new behavior?
![After the changes](https://github.com/supabase/vecs/assets/108121667/5d418948-d671-434a-ab54-e10ed557bbd4)