### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install vecs
 
 ## Usage
 
-Visit the [quickstart guide](https://supabase.github.io/vecs/latest/api) for more complete info.
+Visit the [quickstart guide](https://supabase.github.io/vecs/api) for more complete info.
 
 ```python
 import vecs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ---
 
-**Documentation**: <a href="https://supabase.github.io/vecs/latest/" target="_blank">https://supabase.github.io/vecs/latest/</a>
+**Documentation**: <a href="https://supabase.github.io/vecs/" target="_blank">https://supabase.github.io/vecs/</a>
 
 **Source Code**: <a href="https://github.com/supabase/vecs" target="_blank">https://github.com/supabase/vecs</a>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

https://supabase.github.io/vecs/latest/api and https://supabase.github.io/vecs/latest/ leads to 404

## What is the new behavior?

no 404

## Additional context

.
